### PR TITLE
Capture block httpresponse in get_response, method returns nil for some reason

### DIFF
--- a/active_cmis.gemspec
+++ b/active_cmis.gemspec
@@ -61,16 +61,13 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<nokogiri>, [">= 1.4.1"])
-      s.add_runtime_dependency(%q<ntlm-http>, ["~> 0.1.1"])
       s.add_runtime_dependency(%q<require_relative>, ["~> 1.0.2"])
     else
       s.add_dependency(%q<nokogiri>, [">= 1.4.1"])
-      s.add_dependency(%q<ntlm-http>, ["~> 0.1.1"])
       s.add_dependency(%q<require_relative>, ["~> 1.0.2"])
     end
   else
     s.add_dependency(%q<nokogiri>, [">= 1.4.1"])
-    s.add_dependency(%q<ntlm-http>, ["~> 0.1.1"])
     s.add_dependency(%q<require_relative>, ["~> 1.0.2"])
   end
 end

--- a/lib/active_cmis.rb
+++ b/lib/active_cmis.rb
@@ -1,7 +1,7 @@
 require 'nokogiri'
 require 'net/http'
 require 'net/https'
-require 'net/ntlm_http'
+#require 'net/ntlm_http'
 require 'yaml'
 require 'logger'
 require 'require_relative'


### PR DESCRIPTION
The second commit is needed to get content_stream data  (Alfresco 4, important).

The first one is to circumvent strange behavior in xCMIS (not so important, but I don't know how to remove it from this pull request)
